### PR TITLE
Use app() instead of test support model

### DIFF
--- a/src/Commands/AttachContactUsers.php
+++ b/src/Commands/AttachContactUsers.php
@@ -6,7 +6,6 @@ namespace Tipoff\Forms\Commands;
 
 use Illuminate\Console\Command;
 use Tipoff\Forms\Models\Contact;
-use Tipoff\TestSupport\Models\User;
 
 class AttachContactUsers extends Command
 {
@@ -43,7 +42,7 @@ class AttachContactUsers extends Command
     {
         $contacts = Contact::whereNull('user_id')->get();
         foreach ($contacts as $contact) {
-            $user = User::where('email', '=', $contact->email)->first();
+            $user = app('user')->where('email', '=', $contact->email)->first();
             if ($user) {
                 $contact->user_id = $user->id;
                 $contact->save();

--- a/src/FormsServiceProvider.php
+++ b/src/FormsServiceProvider.php
@@ -15,14 +15,14 @@ class FormsServiceProvider extends TipoffServiceProvider
     public function configureTipoffPackage(TipoffPackage $package): void
     {
         $package
-            ->hasCommands([
-                AttachContactUsers::class,
-            ])
             ->hasPolicies([
                 Contact::class => ContactPolicy::class,
             ])
             ->hasNovaResources([
                 \Tipoff\Forms\Nova\Contact::class,
+            ])
+            ->hasCommands([
+                AttachContactUsers::class,
             ])
             ->name('forms')
             ->hasConfigFile();


### PR DESCRIPTION
I realized in my new command, a slight error was overlooked. I adjusted the user model to reference the `app()` as I seemed to have accidently pulled the test model in by accident.